### PR TITLE
Get-IisConfigurationSection : SiteName Parameter documentation

### DIFF
--- a/Carbon/Functions/Get-IisConfigurationSection.ps1
+++ b/Carbon/Functions/Get-IisConfigurationSection.ps1
@@ -34,7 +34,7 @@ function Get-CIisConfigurationSection
     param(
         [Parameter(Mandatory=$true,ParameterSetName='ForSite')]
         [string]
-        # The site where anonymous authentication should be set.
+        # The site whose configuration should be returned.
         $SiteName,
         
         [Parameter(ParameterSetName='ForSite')]


### PR DESCRIPTION
The documenation for SiteName Parameter refers to setting anonymous authentication.