### PR TITLE
Install-CCertificate can fill up a server's disk if you install a lot of certificates that have private keys.

### DIFF
--- a/Carbon/Carbon.psd1
+++ b/Carbon/Carbon.psd1
@@ -25,7 +25,7 @@
     RootModule = 'Carbon.psm1'
 
     # Version number of this module.
-    ModuleVersion = '2.10.0'
+    ModuleVersion = '2.10.1'
 
     # ID used to uniquely identify this module
     GUID = '075d9444-c01b-48c3-889a-0b3490716fa2'
@@ -359,73 +359,18 @@ All functions are idempotent: when run multiple times with the same arguments, y
 
             # ReleaseNotes of this module
             ReleaseNotes = @'
-# Naming Collisions Solved (Again)
+**Please read 2.10.0 release notes for upgrade notes if you're upgrading from Carbon 2.9.x or earlier.***
 
-Fixed: In Carbon 2.7.0, we added a `C` prefix to all the Carbon functions, with aliases that used the old function
-names to preserve backwards-compatability. We didn't realize at the time that aliases have the highest precedence of
-commands, so Carbon's aliases hid any other commands on your system that may have been named the same. Bad idea. With
-this release, Carbon no longer uses aliases for backwards-compatability. Instead, it dynamically creates shim functions
-named after the old functions. These shim functions write a warning that the function with the old name is deprecated
-then calls the function using its new name. Hopefully, this will finally fix the name collisions problems. The function
-names with out the `C` prefix will be removed in Carbon 3, so update your code to make upgrading easier.
-
-Because Carbon creates these backwards-compatible function shims dynamically, Carbon *won't* create a shim if a
-function with the old name exists. If there is a name conflict between Carbon and another module, if you import that
-module first, Carbon won't export its shim function.
-
-# Carbon on PowerShell Core
-
-We need parts of Carbon to work on PowerShell Core. The current size of Carbon makes that hard (over 200 functions and
-automated tests that take a long time). So, we're breaking Carbon into smaller modules. The new modules will all require
-PowerShell 5.1+. If you use Carbon 2 and the new modules together, you'll get naming conflicts during installation and
-when importing.
-
-The first two modules are already out: Carbon.Core and Carbon.Cryptography. 
-
-# Carbon.Core
-
-Carbon.Core will contain all the functions that are foundational to all or most other future Carbon modules, or generic
-functions we feel are core to Carbon and/or PowerShell. It has no dependencies. The following functions were migrated to
-it:
-
-* `ConvertTo-CBase64` (with some added functionality)
-* `Get-CPowerShellPath`
-* `Invoke-CPowerShell`
-* `Test-COperatingSystem`: Replaces `Test-OSIs32Bit` and `Test-OSIs64Bit`. Tests operating system type, too, so you
-can use this function instead of the `$IsWindows`, `$IsLinux`, or `$IsMacOS` variables. Works on versions of PowerShell
-that don't define those variables.
-* `Test-CPowerShell`: Replaces `Test-PowerShellIs32Bit` and `Test-PowerShellIs64Bit`. Tests edition, too. Use this
-function instead of `$PSVersionTable.PSEdition`. Handles when $PSVersionTable doesn't have the PSEdition property.
-
-# Carbon.Cryptography
-
-Carbon.Crytography contains functions that are used when encrypting and decrypting strings. This is where certificate
-management funtions live. These function were migrated from Carbon:
-
-* `Convert-CSecureStringToString`
-* `Get-CCertificate`: works on Linux and macOS when opening certificate files.
-* `Install-CCertificate`
-* `Uninstall-CCertificate`
-* `Protect-CString`: works on Linux and macOS.
-* `Unprotect-CString`: works on Linux and macOS.
-
-# TL;DR Changes
-
-* Fixed: Carbon's backward compatible aliases replaced with shim functions. Carbon no longer aggressively loads its
-functions.
-* New: Carbon now warns when you're using a function shim with a deprecated name. Update your code so that all Carbon
-functions have a `C` prefix. Carbon has a `Use-CarbonPrefix.ps1` script in its bin directory that will update files to
-use the new prefix.
-* Migrated the following functions to new Carbon.Core and Carbon.Cryptography modules. These functions still exist in
-Carbon 2, so if you use all these modules together, you'll probably run into naming collisions and errors depending on
-how you install, import, and use Carbon. You'll get a warning if you use any of the functions that migrated.
-    * `ConvertTo-CBase64`, `Get-CPowerShellPath`, and `Invoke-CPowerShell` are now in the Carbon.Core module.
-    * The `Test-COSIs32Bit` and `Test-COSIs64Bit` functions merged into a `Test-COperatingSystem` function in the
-    Carbon.Core module.
-    * The `Test-CPowerShellIs32Bit` and `Test-CPowerShellIs64Bit` functions merged into a `Test-CPowerShell` function in
-    the Carbon.Core module.
-    * New: `Convert-CSecureStringToString`, `Get-CCertificate`, `Install-CCertificate`, `Uninstall-CCertificate`,
-    `Protect-CString`, and `Unprotect-CString` migrated to the Carbon.Cryptography module.
+* Fixed: the `Install-CCertificate` function causes an extra file to be written to the Windows directory where private
+keys are saved. Depending on your environment, this could put many, many extra very small files on the file system or a
+full disk.
+* Fixed: the `Install-CCertificate` function could fail to install a certificate with a private key in a remote
+computer's LocalMachine store if you passed in a certificate object to install.
+* Fixed: the `Install-CCertificate` function always installs a certificate even if it exists in the destination store.
+Depending on your environment, this could put many, many extra very small files on the file system or a full disk. Use
+the `-Force` switch to always install a certificate even if it already exists in the destination store.
+* Added a `-Force` switch to the `Install-CCertificate` function to force certificates to be installed if they already
+exist in the destination store.
 '@
         } # End of PSData hashtable
     

--- a/Carbon/Functions/Install-Certificate.ps1
+++ b/Carbon/Functions/Install-Certificate.ps1
@@ -6,24 +6,32 @@ function Install-CCertificate
     Installs a certificate in a given store.
     
     .DESCRIPTION
-    Uses the .NET certificates API to add a certificate to a store for the machine or current user.  The user performing the action must have permission to modify the store or the installation will fail.
+    Uses the .NET certificates API to add a certificate to a store for the machine or current user.  The user performing
+    the action must have permission to modify the store or the installation will fail.
 
-    To install a certificate on a remote computer, create a remoting session with the `New-PSSession` cmdlet, and pass the session object to this function's `Session` parameter. When installing to a remote computer, the certificate's binary data is converted to a base-64 encoded string and sent to the remote computer, where it is converted back into a certificate. If installing a certificate from a file, the file's bytes are converted to base-64, sent to the remote computer, saved as a temporary file, installed, and the temporary file is removed.
+    To install a certificate on a remote computer, create a remoting session with the `New-PSSession` cmdlet, and pass
+    the session object to this function's `Session` parameter. When installing to a remote computer, the certificate's
+    binary data is converted to a base-64 encoded string and sent to the remote computer, where it is converted back
+    into a certificate. If installing a certificate from a file, the file's bytes are converted to base-64, sent to the
+    remote computer, saved as a temporary file, installed, and the temporary file is removed.
 
     The ability to install a certificate on a remote computer was added in Carbon 2.1.0.
     
     .OUTPUTS
-    System.Security.Cryptography.X509Certificates.X509Certificate2. An X509Certificate2 object representing the newly installed certificate.
+    System.Security.Cryptography.X509Certificates.X509Certificate2. An X509Certificate2 object representing the newly
+    installed certificate.
     
     .EXAMPLE
     > Install-CCertificate -Path C:\Users\me\certificate.cer -StoreLocation LocalMachine -StoreName My -Exportable -Password My5up3r53cur3P@55w0rd
     
-    Installs the certificate (which is protected by a password) at C:\Users\me\certificate.cer into the local machine's Personal store.  The certificate is marked exportable.
+    Installs the certificate (which is protected by a password) at C:\Users\me\certificate.cer into the local machine's
+    Personal store.  The certificate is marked exportable.
     
     .EXAMPLE
     Install-CCertificate -Path C:\Users\me\certificate.cer -StoreLocation LocalMachine -StoreName My -ComputerName remote1,remote2
     
-    Demonstrates how to install a certificate from a file on the local computer into the local machine's personal store on two remote cmoputers, remote1 and remote2. Use the `Credential` parameter to connect as a specific principal.
+    Demonstrates how to install a certificate from a file on the local computer into the local machine's personal store
+    on two remote cmoputers, remote1 and remote2. Use the `Credential` parameter to connect as a specific principal.
     #>
     [CmdletBinding(SupportsShouldProcess=$true,DefaultParameterSetName='FromFileInWindowsStore')]
     [OutputType([Security.Cryptography.X509Certificates.X509Certificate2])]
@@ -78,6 +86,10 @@ function Install-CCertificate
         # This parameter was added in Carbon 2.1.0.
         $Session,
 
+        # Re-install the certificate, even if it is already installed. Calls the `Add()` method for store even if the
+        # certificate is in the store. This function assumes that the `Add()` method replaces existing certificates.
+        [switch]$Force,
+
         [switch]$NoWarn
     )
     
@@ -99,7 +111,7 @@ function Install-CCertificate
     
     if( $PSCmdlet.ParameterSetName -like 'FromFile*' )
     {   
-        $resolvedPath = Resolve-Path -Path $Path        
+        $resolvedPath = Resolve-Path -Path $Path
         if( -not $resolvedPath )
         {
             return
@@ -110,26 +122,31 @@ function Install-CCertificate
         $fileBytes = [IO.File]::ReadAllBytes($Path)
         $encodedCert = [Convert]::ToBase64String( $fileBytes )
 
-        $keyFlags = [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeySet
+        # Make sure loading the certificate doesn't leave temporary cruft around on the file system. We're only loading
+        # the cert to get its thumbprint.
+        $keyStorageFlags = @{}
         if( $StoreLocation -eq [Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser )
         {
-            $keyFlags = [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet
+            $keyStorageFlags['KeyStorageFlags'] = 
+                [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::EphemeralKeySet
         }
-        $keyFlags = $keyFlags -bor [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
-    
-        if( $Exportable )
-        {
-            $keyFlags = $keyFlags -bor [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
-        }
-
-        $Certificate = Get-CCertificate -Path $Path -Password $Password -KeyStorageFlags $keyFlags -NoWarn
-        $fromFile = $true
+        $Certificate = Get-CCertificate -Path $Path -Password $Password -NoWarn @keyStorageFlags
     }
     else
     {
         $encodedCert = [Convert]::ToBase64String( $Certificate.RawData )
-        $keyFlags = 0
-        $fromFile = $false
+    }
+
+    $keyFlags = [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::MachineKeySet
+    if( $StoreLocation -eq [Security.Cryptography.X509Certificates.StoreLocation]::CurrentUser )
+    {
+        $keyFlags = [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::UserKeySet
+    }
+    $keyFlags = $keyFlags -bor [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::PersistKeySet
+
+    if( $Exportable )
+    {
+        $keyFlags = $keyFlags -bor [Security.Cryptography.X509Certificates.X509KeyStorageFlags]::Exportable
     }
 
     $invokeCommandArgs = @{ }
@@ -138,36 +155,40 @@ function Install-CCertificate
         $invokeCommandArgs['Session'] = $Session
     }
 
-
     Invoke-Command @invokeCommandArgs -ScriptBlock {
         [CmdletBinding()]
         param(
-            [Parameter(Mandatory=$true)]
-            [string]
+            [Parameter(Mandatory,Position=0)]
             # The base-64 encoded certificate to install.
-            $EncodedCertificate,
+            [String]$EncodedCertificate,
 
             # The password for the certificate.
-            [securestring]
-            $Password,
+            [Parameter(Position=1)]
+            [securestring]$Password,
 
-            [Parameter(Mandatory=$true)]
-            [Security.Cryptography.X509Certificates.StoreLocation]
-            $StoreLocation,
+            [Parameter(Mandatory,Position=2)]
+            [Security.Cryptography.X509Certificates.StoreLocation]$StoreLocation,
         
+            [Parameter(Position=3)]
             $StoreName,
 
-            [string]
-            $CustomStoreName,
+            [Parameter(Position=4)]
+            [String]$CustomStoreName,
 
-            [Security.Cryptography.X509Certificates.X509KeyStorageFlags]
-            $KeyStorageFlags,
+            [Parameter(Position=5)]
+            [Security.Cryptography.X509Certificates.X509KeyStorageFlags]$KeyStorageFlags,
 
-            [bool]
-            $WhatIf,
+            [Parameter(Position=6)]
+            [bool]$WhatIf,
 
-            [Management.Automation.ActionPreference]
-            $Verbosity
+            [Parameter(Position=7)]
+            [Management.Automation.ActionPreference]$Verbosity,
+
+            [Parameter(Position=8)]
+            [switch]$Force,
+
+            [Parameter(Mandatory,Position=9)]
+            [String]$Thumbprint
         )
 
         Set-StrictMode -Version 'Latest'
@@ -177,16 +198,9 @@ function Install-CCertificate
 
         $tempDir = 'Carbon+Install-CCertificate+{0}' -f [IO.Path]::GetRandomFileName()
         $tempDir = Join-Path -Path $env:TEMP -ChildPath $tempDir
-        New-Item -Path $tempDir -ItemType 'Directory' -WhatIf:$false | Out-Null
 
         try
         {
-            $certBytes = [Convert]::FromBase64String( $EncodedCertificate )
-            $certFilePath = Join-Path -Path $tempDir -ChildPath ([IO.Path]::GetRandomFileName())
-            [IO.File]::WriteAllBytes( $certFilePath, $certBytes )
-
-            $cert = New-Object 'Security.Cryptography.X509Certificates.X509Certificate2' ($certFilePath, $Password, $KeyStorageFlags)
-
             if( $CustomStoreName )
             {
                 $store = New-Object 'Security.Cryptography.X509Certificates.X509Store' $CustomStoreName,$StoreLocation
@@ -196,6 +210,30 @@ function Install-CCertificate
                 $store = New-Object 'Security.Cryptography.X509Certificates.X509Store'  ([Security.Cryptography.X509Certificates.StoreName]$StoreName),$StoreLocation
             }
 
+            if( -not $Force )
+            {
+                $store.Open( ([Security.Cryptography.X509Certificates.OpenFlags]::ReadOnly) )
+                try
+                {
+                    if( $store.Certificates | Where-Object { $_.Thumbprint -eq $Thumbprint } )
+                    {
+                        return
+                    }
+                }
+                finally
+                {
+                    $store.Close()
+                }
+            }
+
+            # Only do the file system work if the certificate isn't installed.
+            New-Item -Path $tempDir -ItemType 'Directory' -WhatIf:$false | Out-Null
+
+            $certBytes = [Convert]::FromBase64String( $EncodedCertificate )
+            $certFilePath = Join-Path -Path $tempDir -ChildPath ([IO.Path]::GetRandomFileName())
+            [IO.File]::WriteAllBytes( $certFilePath, $certBytes )
+
+            $cert = New-Object 'Security.Cryptography.X509Certificates.X509Certificate2' ($certFilePath, $Password, $KeyStorageFlags)
             $store.Open( ([Security.Cryptography.X509Certificates.OpenFlags]::ReadWrite) )
 
             $description = $cert.FriendlyName
@@ -213,10 +251,13 @@ function Install-CCertificate
         }
         finally
         {
-            Remove-Item -Path $tempDir -Recurse -ErrorAction Ignore -WhatIf:$false -Force
+            if( (Test-Path -Path $tempDir) )
+            {
+                Remove-Item -Path $tempDir -Recurse -ErrorAction Ignore -WhatIf:$false -Force
+            }
         }
 
-    } -ArgumentList $encodedCert,$Password,$StoreLocation,$StoreName,$CustomStoreName,$keyFlags,$WhatIfPreference,$VerbosePreference
+    } -ArgumentList $encodedCert,$Password,$StoreLocation,$StoreName,$CustomStoreName,$keyFlags,$WhatIfPreference,$VerbosePreference,$Force,$Certificate.Thumbprint
 
     return $Certificate
 }

--- a/Test/Install-Certificate.Tests.ps1
+++ b/Test/Install-Certificate.Tests.ps1
@@ -19,120 +19,197 @@ $TestCert = New-Object 'Security.Cryptography.X509Certificates.X509Certificate2'
 $TestCertProtectedPath = Join-Path -Path $PSScriptRoot -ChildPath 'Certificates\CarbonTestCertificateWithPassword.cer' -Resolve
 $TestCertProtected = New-Object 'Security.Cryptography.X509Certificates.X509Certificate2' $TestCertProtectedPath,'password'
 
+function Measure-MachineKey
+{
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory)]
+        [Security.Cryptography.X509Certificates.StoreLocation]$Location
+    )
+
+    $path = Join-Path -Path $env:APPDATA -ChildPath 'Microsoft\Crypto\RSA\*\*'
+    if( $Location -eq [Security.Cryptography.X509Certificates.StoreLocation]::LocalMachine )
+    {
+        $path = Join-Path -Path $env:ProgramData -ChildPath 'Microsoft\Crypto\RSA\MachineKeys'
+    }
+    Get-ChildItem -Path $path | Measure-Object | Select-Object -ExpandProperty 'Count'
+}
+
+function Reset
+{
+    Uninstall-CCertificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
+    Uninstall-CCertificate -Certificate $TestCert -StoreLocation LocalMachine -StoreName My -NoWarn
+    Uninstall-CCertificate -Certificate $TestCertProtected -StoreLocation CurrentUser -StoreName My -NoWarn
+    Uninstall-CCertificate -Certificate $TestCertProtected -StoreLocation LocalMachine -StoreName My -NoWarn
+}
+
 Describe "Install-Certificate" {
 
-    function Assert-CertificateInstalled
+    foreach( $location in @('CurrentUser', 'LocalMachine') )
     {
-        param(
-            $StoreLocation = 'CurrentUser', 
-            $StoreName = 'My',
-            $ExpectedCertificate = $TestCert
-        )
-        $cert = Get-Certificate -Thumbprint $ExpectedCertificate.Thumbprint -StoreLocation $StoreLocation -StoreName $StoreName -NoWarn
-        $cert | Should Not BeNullOrEmpty | Out-Null
-        $cert.Thumbprint | Should Be $ExpectedCertificate.Thumbprint | Out-Null
-        return $cert
-    }
+        Context "for $($location)" {
+            function Assert-CertificateInstalled
+            {
+                param(
+                    $StoreLocation = 'CurrentUser', 
+                    $StoreName = 'My',
+                    $ExpectedCertificate = $TestCert
+                )
 
-    BeforeEach {
-        $Global:Error.Clear()
+                $duration = [Diagnostics.Stopwatch]::StartNew()
+                $timeout = [TimeSpan]::New(0, 0, 10)
+                do
+                {
+                    $cert = Get-CCertificate -Thumbprint $ExpectedCertificate.Thumbprint `
+                                             -StoreLocation $StoreLocation `
+                                             -StoreName $StoreName `
+                                             -NoWarn
+                    if( $cert )
+                    {
+                        break
+                    }
 
-        if( (Get-Certificate -Thumbprint $TestCert.Thumbprint -StoreLocation CurrentUser -StoreName My -NoWarn) )
-        {
-            Uninstall-Certificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
+                    Write-Verbose "Couldn't find $($StoreLocation)\$($SToreName)\$($ExpectedCertificate.Thumbprint). Trying again in 100ms." -Verbose
+                    Start-Sleep -Milliseconds 100
+                }
+                while( $duration.Elapsed -lt $timeout )
+                $duration.Stop()
+                $duration = $null
+
+                $cert | Should -Not -BeNullOrEmpty | Out-Null
+                $cert.Thumbprint | Should -Be $ExpectedCertificate.Thumbprint | Out-Null
+                if( $cert.HasPrivateKey )
+                {
+                    $cert.PrivateKey | Should -Not -BeNullOrEmpty
+                }
+                return $cert
+            }
+
+            BeforeEach {
+                $Global:Error.Clear()
+                Reset
+            }
+
+            AfterEach {
+                Reset
+            }
+
+            It 'should install certificate' {
+                $cert = Install-CCertificate -Path $TestCertPath -StoreLocation $location -StoreName My
+                $cert.Thumbprint | Should -Be $TestCert.Thumbprint
+                $cert = Assert-CertificateInstalled -StoreLocation $location -StoreName My 
+                {
+                    $bytes = $cert.Export( [Security.Cryptography.X509Certificates.X509ContentType]::Pfx )
+                } | Should -Throw
+            }
+
+            It 'should install certificate with relative path' {
+                $DebugPreference = 'Continue'
+                Push-Location -Path $PSScriptRoot
+                try
+                {
+                    $path = '.\Certificates\{0}' -f (Split-Path -Leaf -Path $TestCertPath)
+                    $cert = Install-CCertificate -Path $path -StoreLocation $location -StoreName My -Verbose -NoWarn
+                    $cert.Thumbprint | Should -Be $TestCert.Thumbprint
+                    $cert = Assert-CertificateInstalled -StoreLocation $location -StoreName My 
+                }
+                finally
+                {
+                    Pop-Location
+                }
+            }
+
+            It 'should install certificate as exportable' {
+                $cert = Install-CCertificate -Path $TestCertPath -StoreLocation $location -StoreName My -Exportable -NoWarn
+                $cert.Thumbprint | Should -Be $TestCert.Thumbprint
+                $cert = Assert-CertificateInstalled -StoreLocation $location -StoreName My 
+                $bytes = $cert.Export( [Security.Cryptography.X509Certificates.X509ContentType]::Pfx )
+                $bytes | Should -Not -BeNullOrEmpty
+            }
+
+            It 'should install certificate in custom store' {
+                $cert = Install-CCertificate -Path $TestCertPath -StoreLocation $location -CustomStoreName 'SharePoint'  -NoWarn
+                $cert | Should -Not -BeNullOrEmpty
+                "cert:\$($location)\SharePoint" | Should -Exist
+                "cert:\$($location)\SharePoint\$($cert.Thumbprint)" | Should -Exist
+            }
+
+            It 'should install certificate idempotently' {
+                $countOfPrivateKeys = Measure-MachineKey $location
+                Install-CCertificate -Path $TestCertProtectedPath `
+                                    -Password 'password' `
+                                    -StoreLocation $location `
+                                    -StoreName My `
+                                    -NoWarn
+                $Global:Error | Should -BeNullOrEmpty
+                Install-CCertificate -Path $TestCertProtectedPath `
+                                    -Password 'password' `
+                                    -StoreLocation $location `
+                                    -StoreName My `
+                                    -NoWarn
+                $Global:Error | Should -BeNullOrEmpty
+                Assert-CertificateInstalled $location My $TestCertProtected
+                Measure-MachineKey $location | Should -Be ($countOfPrivateKeys + 1)
+            }
+
+            It 'should re-install certificate when forced' {
+                $countOfPrivateKeys = Measure-MachineKey $location
+                Install-CCertificate -Path $TestCertProtectedPath `
+                                    -Password 'password' `
+                                    -StoreLocation $location `
+                                    -StoreName My `
+                                    -NoWarn
+                $Global:Error | Should -BeNullOrEmpty
+                Install-CCertificate -Path $TestCertProtectedPath `
+                                    -Password 'password' `
+                                    -StoreLocation $location `
+                                    -StoreName My `
+                                    -NoWarn `
+                                    -Force
+                $Global:Error | Should -BeNullOrEmpty
+                Assert-CertificateInstalled $location My $TestCertProtected
+                Measure-MachineKey $location | Should -Be ($countOfPrivateKeys + 2)
+            }
+
+            It 'should install certificate' {
+                $cert = Install-CCertificate -Certificate $TestCert -StoreLocation $location -StoreName My -NoWarn
+                $cert | Should -Not -BeNullOrEmpty
+                Assert-CertificateInstalled $location My
+            }
+
+            It 'should install password protected certificate' {
+                $countOfPrivateKeys = Measure-MachineKey $location
+                $cert = Install-CCertificate -Path $TestCertProtectedPath `
+                                            -Password 'password' `
+                                            -StoreLocation $location `
+                                            -StoreName My `
+                                            -NoWarn
+                $cert | Should -Not -BeNullOrEmpty
+                Assert-CertificateInstalled $location My $TestCertProtected
+                # Regression: make sure importing the certificate doesn't leave behind an extra file in MachineKeys.
+                Measure-MachineKey $location | Should -Be ($countOfPrivateKeys + 1)
+            }
+
+            It 'should install certificate in remote computer' -Skip:(Test-Path -Path 'env:APPVEYOR') {
+                $session = New-PSSession -ComputerName $env:COMPUTERNAME
+                try
+                {
+                    $cert = Install-CCertificate -Certificate $TestCert -StoreLocation $location -StoreName My -Session $session -NoWarn
+                    $cert | Should -Not -BeNullOrEmpty
+                    Assert-CertificateInstalled $location My
+                }
+                finally
+                {
+                    Remove-PSSession -Session $session
+                }
+            }
+                
+            It 'should support ShouldProcess' {
+                $cert = Install-CCertificate -Path $TestCertPath -StoreLocation $location -StoreName My -WhatIf -NoWarn
+                $cert.Thumbprint | Should -Be $TestCert.Thumbprint
+                Join-Path -Path "cert:\$($location)\My" -ChildPath $TestCert.Thumbprint |
+                    Should -Not -Exist
+            }
         }
-
-        if( (Get-Certificate -Thumbprint $TestCertProtected.Thumbprint -StoreLocation CurrentUser -StoreName My -NoWarn) )
-        {
-            Uninstall-Certificate -Certificate $TestCertProtected -StoreLocation CurrentUser -StoreName My -NoWarn
-        }
-    }
-
-    AfterEach {
-        Uninstall-Certificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
-        Uninstall-Certificate -Certificate $TestCert -StoreLocation LocalMachine -StoreName My -NoWarn
-        Uninstall-Certificate -Certificate $TestCertProtected -StoreLocation CurrentUser -StoreName My -NoWarn
-        Uninstall-Certificate -Certificate $TestCertProtected -StoreLocation LocalMachine -StoreName My -NoWarn
-    }
-
-    It 'should install certificate to local machine' {
-        $cert = Install-Certificate -Path $TestCertPath -StoreLocation CurrentUser -StoreName My
-        $cert.Thumbprint | Should Be $TestCert.Thumbprint
-        $cert = Assert-CertificateInstalled -StoreLocation CurrentUser -StoreName My 
-        {
-            $bytes = $cert.Export( [Security.Cryptography.X509Certificates.X509ContentType]::Pfx )
-        } | Should Throw
-    }
-
-    It 'should install certificate to local machine with relative path' {
-        $DebugPreference = 'Continue'
-        Push-Location -Path $PSScriptRoot
-        try
-        {
-            $path = '.\Certificates\{0}' -f (Split-Path -Leaf -Path $TestCertPath)
-            $cert = Install-Certificate -Path $path -StoreLocation CurrentUser -StoreName My -Verbose -NoWarn
-            $cert.Thumbprint | Should Be $TestCert.Thumbprint
-            $cert = Assert-CertificateInstalled -StoreLocation CurrentUser -StoreName My 
-        }
-        finally
-        {
-            Pop-Location
-        }
-    }
-
-    It 'should install certificate to local machine as exportable' {
-        $cert = Install-Certificate -Path $TestCertPath -StoreLocation CurrentUser -StoreName My -Exportable -NoWarn
-        $cert.Thumbprint | Should Be $TestCert.Thumbprint
-        $cert = Assert-CertificateInstalled -StoreLocation CurrentUser -StoreName My 
-        $bytes = $cert.Export( [Security.Cryptography.X509Certificates.X509ContentType]::Pfx )
-        $bytes | Should Not BeNullOrEmpty
-    }
-
-    It 'should install certificate in custom store' {
-        $cert = Install-Certificate -Path $TestCertPath -StoreLocation CurrentUser -CustomStoreName 'SharePoint'  -NoWarn
-        $cert | Should Not BeNullOrEmpty
-        'cert:\CurrentUser\SharePoint' | Should Exist
-        ('cert:\CurrentUser\SharePoint\{0}' -f $cert.Thumbprint) | Should Exist
-    }
-
-    It 'should install certificate idempotently' {
-        Install-Certificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
-        $Global:Error | Should BeNullOrEmpty
-        Install-Certificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
-        $Global:Error | Should BeNullOrEmpty
-        Assert-CertificateInstalled CurrentUser My
-    }
-
-    It 'should install certificate' {
-        $cert = Install-Certificate -Certificate $TestCert -StoreLocation CurrentUser -StoreName My -NoWarn
-        $cert | Should Not BeNullOrEmpty
-        Assert-CertificateInstalled CurrentUser My
-    }
-
-    It 'should install password protected certificate' {
-        $cert = Install-Certificate -Certificate $TestCertProtected -StoreLocation CurrentUser -StoreName My -NoWarn
-        $cert | Should Not BeNullOrEmpty
-        Assert-CertificateInstalled CurrentUser My $TestCertProtected
-    }
-
-    It 'should install certificate in remote computer' -Skip:(Test-Path -Path 'env:APPVEYOR') {
-        $session = New-PSSession -ComputerName $env:COMPUTERNAME
-        try
-        {
-            $cert = Install-Certificate -Certificate $TestCert -StoreLocation LocalMachine -StoreName My -Session $session -NoWarn
-            $cert | Should Not BeNullOrEmpty
-            Assert-CertificateInstalled LocalMachine My
-        }
-        finally
-        {
-            Remove-PSSession -Session $session
-        }
-    }
-        
-    It 'should support ShouldProcess' {
-        $cert = Install-Certificate -Path $TestCertPath -StoreLocation CurrentUser -StoreName My -WhatIf -NoWarn
-        $cert.Thumbprint | Should Be $TestCert.Thumbprint
-        Join-Path -Path 'cert:\CurrentUser\My' -ChildPath $TestCert.Thumbprint |
-            Should Not Exist
     }
 }


### PR DESCRIPTION
Or leave a bunch of really small files on the file system, which uses extra space.