### PR TITLE
Deprecating functions that have moved to their own modules

### DIFF
--- a/Carbon/Carbon.psm1.Import.Obsolete.ps1
+++ b/Carbon/Carbon.psm1.Import.Obsolete.ps1
@@ -650,7 +650,7 @@ function Get-CPowershellPath
     }
 
     # x86 OS/x86 PowerShell. There's no 64-bit anything, so just return $PSHOME.
-    if( Test-COSIs32Bit )
+    if (Test-COSIs32Bit -NoWarn)
     {
         if( $x86 )
         {
@@ -2555,7 +2555,7 @@ function Test-COSIs32Bit
     #>
     [CmdletBinding()]
     param(
-        [switch]$NoWarn
+        [switch] $NoWarn
     )
 
     Set-StrictMode -Version 'Latest'

--- a/whiskey.yml
+++ b/whiskey.yml
@@ -3,8 +3,8 @@ Build:
 - Version:
     Path: Carbon\Carbon.psd1
     Prerelease:
-    - "*/*": alpha$(WHISKEY_BUILD_NUMBER)
-    - develop: rc$(WHISKEY_BUILD_NUMBER)
+    - master: ""
+    - "*": rc1
 - Exec:
     OnlyBy: BuildServer
     Path: appveyor


### PR DESCRIPTION
IIS funtions moved to Carbon.IIS.

HTTPS certificate binding functions moved to Carbon.Windows.HttpServer.

Resolve-CFullPath moved to Carbon.Core.